### PR TITLE
Full Protein -> Logits scoring! Woohoo.

### DIFF
--- a/ferritin-featurizers/src/models/ligandmpnn/model.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/model.rs
@@ -392,7 +392,7 @@ impl ProteinMPNN {
                     h_v = new_h_v;
                     h_e = new_h_e;
                 }
-
+                println!("Encoding Complete!!");
                 Ok((h_v, h_e, e_idx))
             }
             ModelTypes::LigandMPNN => {

--- a/ferritin-featurizers/src/models/ligandmpnn/model.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/model.rs
@@ -1075,23 +1075,23 @@ impl ProteinMPNN {
                 // (mask_fw, mask_bw, e_idx, decoding_order)
             }
             None => {
-                println!("scoring 06");
                 let b_decoder = b_decoder as usize;
                 let e_idx = e_idx.repeat(&[b_decoder, 1, 1])?;
-                println!("scoring 07");
                 let permutation_matrix_reverse = one_hot(decoding_order.clone(), l, 1., 0.)?;
                 let tril = Tensor::tril2(l, DType::F64, device)?;
-                println!("scoring 08");
+                let tril = tril.unsqueeze(0)?;
                 let temp = tril.matmul(&permutation_matrix_reverse.transpose(1, 2)?)?; // shape (b, i, q)
-                println!("scoring 09");
                 let order_mask_backward =
                     temp.matmul(&permutation_matrix_reverse.transpose(1, 2)?)?; // shape (b, q, p)
-                println!("scoring 10");
                 let mask_attend = order_mask_backward
                     .gather(&e_idx, 2)?
                     .unsqueeze(D::Minus1)?;
                 let mask_1d = mask.unwrap().reshape((b, l, 1, 1))?;
+                println!("scoring 12");
+                println!("mask_1d dims: {:?}", mask_1d.dims());
+                println!("mask_attend dims: {:?}", mask_attend.dims());
                 let mask_bw = mask_1d.mul(&mask_attend)?;
+                println!("scoring 13");
                 let mask_fw = mask_1d.mul(&(mask_attend - 1.0)?.neg()?)?;
                 (mask_fw, mask_bw, e_idx, decoding_order)
             }

--- a/ferritin-featurizers/src/models/ligandmpnn/model.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/model.rs
@@ -373,7 +373,6 @@ impl ProteinMPNN {
     }
     fn encode(&self, features: &ProteinFeatures) -> Result<(Tensor, Tensor, Tensor)> {
         // todo: get device more elegantly
-        println!("Encoding!");
         let device = &candle_core::Device::Cpu;
         let s_true = &features.get_sequence();
         let (b, l) = s_true.dims2()?;
@@ -402,7 +401,6 @@ impl ProteinMPNN {
                 ))?;
                 let mask_attend = (&mask_expanded * &mask_attend)?;
 
-                println!("Encode: Through the encoder layers...");
                 for layer in &self.encoder_layers {
                     let (new_h_v, new_h_e) = layer.forward(
                         &h_v,
@@ -415,7 +413,6 @@ impl ProteinMPNN {
                     h_v = new_h_v;
                     h_e = new_h_e;
                 }
-                println!("Encoding Complete!!");
                 Ok((h_v, h_e, e_idx))
             }
             ModelTypes::LigandMPNN => {

--- a/ferritin-featurizers/src/models/ligandmpnn/model.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/model.rs
@@ -127,9 +127,31 @@ impl EncLayer {
         println!("EncLayer: Forward method.");
         let h_ev = cat_neighbors_nodes(h_v, h_e, e_idx)?;
         println!("EncLayer: 01");
-        let h_v_expand = h_v.unsqueeze(D::Minus1)?.expand(h_ev.shape().dims())?;
+
+        println!("h_v shape: {:?}", h_v.dims());
+        println!("h_v dtype: {:?}", h_v.dtype());
+        println!("h_ev shape: {:?}", h_ev.dims());
+        println!("h_ev dtype: {:?}", h_ev.dtype());
+
+        let h_v_expand = h_v.unsqueeze(D::Minus2)?;
+        println!("h_v_expand shape after unsqueeze: {:?}", h_v_expand.dims());
+
+        // Explicitly specify the expansion dimensions
+        let expand_shape = [
+            h_ev.dims()[0],       // batch size
+            h_ev.dims()[1],       // sequence length
+            h_ev.dims()[2],       // number of neighbors
+            h_v_expand.dims()[3], // hidden dimension
+        ];
+        let h_v_expand = h_v_expand.expand(&expand_shape)?;
+        let h_v_expand = h_v_expand.to_dtype(h_ev.dtype())?;
+
         println!("EncLayer: 02");
+        // Now concatenate along the last dimension
         let h_ev = Tensor::cat(&[&h_v_expand, &h_ev], D::Minus1)?;
+
+        // println!("EncLayer: 02");
+        // let h_ev = Tensor::cat(&[&h_v_expand, &h_ev], D::Minus1)?;
         println!("EncLayer: 03");
         let h_message = self
             .w1

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -35,9 +35,12 @@ pub fn cat_neighbors_nodes(
     h_neighbors: &Tensor,
     e_idx: &Tensor,
 ) -> Result<Tensor> {
-    println!("In Cas_neighbors");
     let h_nodes_gathered = gather_nodes(h_nodes, e_idx)?;
-    Tensor::cat(&[h_neighbors, &h_nodes_gathered], D::Minus1)
+    // todo: fix this hacky Dtype
+    Tensor::cat(
+        &[h_neighbors, &h_nodes_gathered.to_dtype(DType::F32)?],
+        D::Minus1,
+    )
 }
 
 /// Retrieve the nearest Neighbor of a set of coordinates.
@@ -293,7 +296,7 @@ pub fn gather_nodes(nodes: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {
     // Gather features
     let neighbor_features = nodes.gather(&neighbors_flat, 1)?;
     // Reshape back to [B, N, K, C]
-    neighbor_features.reshape((batch_size, n_nodes, k_neighbors, n_features));
+    neighbor_features.reshape((batch_size, n_nodes, k_neighbors, n_features))
 }
 
 pub fn gather_nodes_t(nodes: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -279,7 +279,6 @@ pub fn gather_edges(edges: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {
 /// Features [B,N,C] at Neighbor indices [B,N,K] => [B,N,K,C]
 /// Flatten and expand indices per batch [B,N,K] => [B,NK] => [B,NK,C]
 pub fn gather_nodes(nodes: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {
-    println!("In gather_nodes");
     let (batch_size, n_nodes, n_features) = nodes.dims3()?;
     let (_, _, k_neighbors) = neighbor_idx.dims3()?;
     // Reshape neighbor_idx to [B, N*K]
@@ -289,12 +288,12 @@ pub fn gather_nodes(nodes: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {
         .unsqueeze(2)? // Add feature dimension [B, N*K, 1]
         .expand((batch_size, n_nodes * k_neighbors, n_features))?; // Expand to [B, N*K, C]
 
-    println!("Entering the Gather pass...");
-    println!("neighbors_flat: {:?}", &neighbors_flat.dims());
+    // make contiguous for the gather.
+    let neighbors_flat = neighbors_flat.contiguous()?;
     // Gather features
     let neighbor_features = nodes.gather(&neighbors_flat, 1)?;
     // Reshape back to [B, N, K, C]
-    neighbor_features.reshape((batch_size, n_nodes, k_neighbors, n_features))
+    neighbor_features.reshape((batch_size, n_nodes, k_neighbors, n_features));
 }
 
 pub fn gather_nodes_t(nodes: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {


### PR DESCRIPTION
```shell
cargo test -p ferritin-featurizers test_cli_command_run_example_01 -- --nocapture
```

```rust
Ok(
 ScoreOutput {
    s: Tensor[dims 1, 93; u32], 
    log_probs: Tensor[dims 1, 93, 21; f32], 
    logits: Tensor[dims 1, 93, 21; f32], 
   decoding_order: Tensor[dims 1, 93; u32] })
```


Mostly the issue is making the broadcasting dimensions explicit.