### PR TITLE
Begin Refactoring LigandMPNN CLI Call to use Metal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,9 +1556,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e61e6a12c4b0660f105c11cbce42a5b33a392e73caaf465261b24210878fbe0e"
 dependencies = [
  "byteorder",
+ "candle-metal-kernels",
  "gemm",
  "half",
  "memmap2",
+ "metal 0.27.0",
  "num-traits",
  "num_cpus",
  "rand",
@@ -1567,6 +1569,7 @@ dependencies = [
  "safetensors",
  "thiserror",
  "ug",
+ "ug-metal",
  "yoke",
  "zip",
 ]
@@ -1593,13 +1596,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-metal-kernels"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2db22aa60f6927d706fa8df2dabe5c7ca2919ba056c69c0c94aa6bdb5ca31c9"
+dependencies = [
+ "metal 0.27.0",
+ "once_cell",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "candle-nn"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2032a3a41999801c5997ee7896ce816c361c49988435dedb7830634293c0798e"
 dependencies = [
  "candle-core",
+ "candle-metal-kernels",
  "half",
+ "metal 0.27.0",
  "num-traits",
  "rayon",
  "safetensors",
@@ -3885,6 +3902,21 @@ dependencies = [
 
 [[package]]
 name = "metal"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "metal"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
@@ -4241,6 +4273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+ "objc_exception",
 ]
 
 [[package]]
@@ -4444,6 +4477,15 @@ dependencies = [
  "objc2",
  "objc2-core-location",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -6103,6 +6145,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ug-metal"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4ed1df2c20a1a138f993041f650cc84ff27aaefb4342b7f986e77d00e80799"
+dependencies = [
+ "half",
+ "metal 0.29.0",
+ "objc",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "ug",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6519,7 +6576,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal",
+ "metal 0.29.0",
  "naga",
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,8 +1552,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61e6a12c4b0660f105c11cbce42a5b33a392e73caaf465261b24210878fbe0e"
+source = "git+https://github.com/huggingface/candle.git#dba7a9c93e4c84c8197e8a5b56f40adcf2650bde"
 dependencies = [
  "byteorder",
  "candle-metal-kernels",
@@ -1598,8 +1597,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2db22aa60f6927d706fa8df2dabe5c7ca2919ba056c69c0c94aa6bdb5ca31c9"
+source = "git+https://github.com/huggingface/candle.git#dba7a9c93e4c84c8197e8a5b56f40adcf2650bde"
 dependencies = [
  "metal 0.27.0",
  "once_cell",
@@ -1610,8 +1608,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2032a3a41999801c5997ee7896ce816c361c49988435dedb7830634293c0798e"
+source = "git+https://github.com/huggingface/candle.git#dba7a9c93e4c84c8197e8a5b56f40adcf2650bde"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
@@ -1627,8 +1624,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88bf4dbf13c3fa0a51624e4a2bf4db1d97596bbefd471424892a0b852013b7c"
+source = "git+https://github.com/huggingface/candle.git#dba7a9c93e4c84c8197e8a5b56f40adcf2650bde"
 dependencies = [
  "byteorder",
  "candle-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.8.0"
-source = "git+https://github.com/huggingface/candle.git#dba7a9c93e4c84c8197e8a5b56f40adcf2650bde"
+source = "git+https://github.com/zachcp/candle.git?branch=20241201-SA#5e648c32dee876e2fcf1afd06255392a6ba741e3"
 dependencies = [
  "byteorder",
  "candle-metal-kernels",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.8.0"
-source = "git+https://github.com/huggingface/candle.git#dba7a9c93e4c84c8197e8a5b56f40adcf2650bde"
+source = "git+https://github.com/zachcp/candle.git?branch=20241201-SA#5e648c32dee876e2fcf1afd06255392a6ba741e3"
 dependencies = [
  "metal 0.27.0",
  "once_cell",
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.8.0"
-source = "git+https://github.com/huggingface/candle.git#dba7a9c93e4c84c8197e8a5b56f40adcf2650bde"
+source = "git+https://github.com/zachcp/candle.git?branch=20241201-SA#5e648c32dee876e2fcf1afd06255392a6ba741e3"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.8.0"
-source = "git+https://github.com/huggingface/candle.git#dba7a9c93e4c84c8197e8a5b56f40adcf2650bde"
+source = "git+https://github.com/zachcp/candle.git?branch=20241201-SA#5e648c32dee876e2fcf1afd06255392a6ba741e3"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -2467,6 +2467,7 @@ dependencies = [
  "assert_cmd",
  "candle-core",
  "candle-hf-hub",
+ "candle-metal-kernels",
  "candle-nn",
  "candle-transformers",
  "clap",

--- a/ferritin-featurizers/Cargo.toml
+++ b/ferritin-featurizers/Cargo.toml
@@ -8,18 +8,22 @@ description.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-candle-core = { git = "https://github.com/huggingface/candle.git", package = "candle-core", features = [
+
+candle-metal-kernels = { git = "https://github.com/zachcp/candle.git", package = "candle-metal-kernels", branch = "20241201-SA" }
+candle-core = { git = "https://github.com/zachcp/candle.git", package = "candle-core", features = [
     "metal",
-] }
+], branch = "20241201-SA" }
+
 # candle-core = { version = "0.8", features = ["metal"] }
 candle-hf-hub = "0.3.3"
+
 # candle-nn = { version = "0.8", features = ["metal"] }
-candle-nn = { git = "https://github.com/huggingface/candle.git", package = "candle-nn", features = [
+candle-nn = { git = "https://github.com/zachcp/candle.git", package = "candle-nn", features = [
     "metal",
-] }
-candle-transformers = { git = "https://github.com/huggingface/candle.git", package = "candle-transformers", features = [
+], branch = "20241201-SA" }
+candle-transformers = { git = "https://github.com/zachcp/candle.git", package = "candle-transformers", features = [
     "metal",
-] }
+], branch = "20241201-SA" }
 # candle-transformers = "0.8.0"
 clap = "4.5.21"
 ferritin-core = { path = "../ferritin-core" }

--- a/ferritin-featurizers/Cargo.toml
+++ b/ferritin-featurizers/Cargo.toml
@@ -8,6 +8,7 @@ description.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+# candle-core = { git = "https://github.com/zachcp/candle.git", branch = "20241130-metal-dep-bump", features = ["metal"] }
 candle-core = { version = "0.8", features = ["metal"] }
 candle-hf-hub = "0.3.3"
 candle-nn = { version = "0.8", features = ["metal"] }

--- a/ferritin-featurizers/Cargo.toml
+++ b/ferritin-featurizers/Cargo.toml
@@ -17,7 +17,10 @@ candle-hf-hub = "0.3.3"
 candle-nn = { git = "https://github.com/huggingface/candle.git", package = "candle-nn", features = [
     "metal",
 ] }
-candle-transformers = "0.8.0"
+candle-transformers = { git = "https://github.com/huggingface/candle.git", package = "candle-transformers", features = [
+    "metal",
+] }
+# candle-transformers = "0.8.0"
 clap = "4.5.21"
 ferritin-core = { path = "../ferritin-core" }
 itertools.workspace = true

--- a/ferritin-featurizers/Cargo.toml
+++ b/ferritin-featurizers/Cargo.toml
@@ -8,10 +8,15 @@ description.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-# candle-core = { git = "https://github.com/zachcp/candle.git", branch = "20241130-metal-dep-bump", features = ["metal"] }
-candle-core = { version = "0.8", features = ["metal"] }
+candle-core = { git = "https://github.com/huggingface/candle.git", package = "candle-core", features = [
+    "metal",
+] }
+# candle-core = { version = "0.8", features = ["metal"] }
 candle-hf-hub = "0.3.3"
-candle-nn = { version = "0.8", features = ["metal"] }
+# candle-nn = { version = "0.8", features = ["metal"] }
+candle-nn = { git = "https://github.com/huggingface/candle.git", package = "candle-nn", features = [
+    "metal",
+] }
 candle-transformers = "0.8.0"
 clap = "4.5.21"
 ferritin-core = { path = "../ferritin-core" }

--- a/ferritin-featurizers/Cargo.toml
+++ b/ferritin-featurizers/Cargo.toml
@@ -8,9 +8,9 @@ description.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-candle-core = "0.8"
+candle-core = { version = "0.8", features = ["metal"] }
 candle-hf-hub = "0.3.3"
-candle-nn = "0.8"
+candle-nn = { version = "0.8", features = ["metal"] }
 candle-transformers = "0.8.0"
 clap = "4.5.21"
 ferritin-core = { path = "../ferritin-core" }

--- a/ferritin-featurizers/src/commands/run.rs
+++ b/ferritin-featurizers/src/commands/run.rs
@@ -60,6 +60,7 @@ pub fn execute(
     println!("About to Load the model!");
     let model = exec.load_model()?;
     println!("Model Loaded!");
+    println!("Model Loaded on the {:?}", model.device);
 
     println!("Generating Protein Features");
     let prot_features = exec.generate_protein_features()?;

--- a/ferritin-featurizers/src/commands/run.rs
+++ b/ferritin-featurizers/src/commands/run.rs
@@ -2,7 +2,30 @@ use crate::models::ligandmpnn::configs::{
     AABiasConfig, LigandMPNNConfig, MPNNExecConfig, MembraneMPNNConfig, ModelTypes, MultiPDBConfig,
     ResidueControl, RunConfig,
 };
-use candle_core::Device;
+use candle_core::utils::{cuda_is_available, metal_is_available};
+use candle_core::{Device, Result};
+
+pub fn device(cpu: bool) -> Result<Device> {
+    if cpu {
+        Ok(Device::Cpu)
+    } else if cuda_is_available() {
+        Ok(Device::new_cuda(0)?)
+    } else if metal_is_available() {
+        Ok(Device::new_metal(0)?)
+    } else {
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            println!(
+                "Running on CPU, to run on GPU(metal), build this example with `--features metal`"
+            );
+        }
+        #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+        {
+            println!("Running on CPU, to run on GPU, build this example with `--features cuda`");
+        }
+        Ok(Device::Cpu)
+    }
+}
 
 pub fn execute(
     seed: i32,
@@ -17,7 +40,7 @@ pub fn execute(
     multi_pdb_config: MultiPDBConfig,
 ) -> anyhow::Result<()> {
     // todo - whats the best way to handle device?
-    let device = &Device::Cpu;
+    let device = device(false)?;
 
     let model_type = model_type.unwrap_or(ModelTypes::ProteinMPNN);
 

--- a/ferritin-featurizers/src/models/ligandmpnn/featurizer.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/featurizer.rs
@@ -24,7 +24,7 @@ fn is_heavy_atom(element: &Element) -> bool {
 
 /// Convert the AtomCollection into a struct that can be passed to a model.
 pub trait LMPNNFeatures {
-    fn encode_amino_acids(&self, device: &Device) -> Result<(Tensor)>; // ( residue types )
+    fn encode_amino_acids(&self, device: &Device) -> Result<Tensor>; // ( residue types )
     fn featurize(&self, device: &Device) -> Result<ProteinFeatures>; // need more control over this featurization process
     fn get_res_index(&self) -> Vec<u32>;
     fn to_numeric_backbone_atoms(&self, device: &Device) -> Result<Tensor>; // [residues, N/CA/C/O, xyz]

--- a/ferritin-featurizers/src/models/ligandmpnn/model.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/model.rs
@@ -573,10 +573,7 @@ impl ProteinMPNN {
                 let bias = bias.repeat((b, 1, 1))?;
                 let mut all_probs = Tensor::zeros((b, l, 20), sample_dtype, device)?;
                 let mut all_log_probs = Tensor::zeros((b, l, 21), sample_dtype, device)?; // why is this one 21 and the others are 20?
-
-                // let mut h_s = Tensor::zeros_like(&h_v)?.contiguous()?;
                 let mut h_s = Tensor::zeros_like(&h_v)?;
-
                 let s = (Tensor::ones((b, l), DType::I64, device)? * 20.)?;
                 let mut h_v_stack = vec![h_v.clone()];
 

--- a/ferritin-featurizers/src/models/ligandmpnn/model.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/model.rs
@@ -548,7 +548,7 @@ impl ProteinMPNN {
         match symmetry_residues {
             None => {
                 let e_idx = e_idx.repeat(&[b, 1, 1])?.contiguous()?;
-                let permutation_matrix_reverse = one_hot(decoding_order.clone(), l, 1., 0.)?;
+                let permutation_matrix_reverse = one_hot(decoding_order.clone(), l, 1., 0.)?.to_dtype(sample_dtype)?;
                 let tril = Tensor::tril2(l, sample_dtype, device)?;
                 let tril = tril.unsqueeze(0)?;
                 let temp = tril.matmul(&permutation_matrix_reverse.transpose(1, 2)?)?; //tensor of shape (b, i, q)

--- a/ferritin-featurizers/src/models/ligandmpnn/model.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/model.rs
@@ -27,7 +27,7 @@ pub fn multinomial_sample(probs: &Tensor, temperature: f64, seed: u64) -> Result
     );
 
     // Sample from the probabilities
-    let idx = logits_processor.sample(&probs)?;
+    let idx = logits_processor.sample(probs)?;
 
     // Convert to tensor
     Tensor::new(&[idx], probs.device())

--- a/ferritin-featurizers/src/models/ligandmpnn/model.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/model.rs
@@ -568,12 +568,15 @@ impl ProteinMPNN {
                 let s_true = s_true.repeat((b, 1))?;
                 let h_v = h_v.repeat((b, 1, 1))?;
                 let h_e = h_e.repeat((b, 1, 1, 1))?;
-                let chain_mask = &chain_mask.repeat((b, 1))?.contiguous()?;
                 let mask = x_mask.as_ref().unwrap().repeat((b, 1))?.contiguous()?;
-                let bias = bias.repeat((b, 1, 1))?.contiguous()?;
+                let chain_mask = &chain_mask.repeat((b, 1))?;
+                let bias = bias.repeat((b, 1, 1))?;
                 let mut all_probs = Tensor::zeros((b, l, 20), sample_dtype, device)?;
                 let mut all_log_probs = Tensor::zeros((b, l, 21), sample_dtype, device)?; // why is this one 21 and the others are 20?
-                let mut h_s = Tensor::zeros_like(&h_v)?.contiguous()?;
+
+                // let mut h_s = Tensor::zeros_like(&h_v)?.contiguous()?;
+                let mut h_s = Tensor::zeros_like(&h_v)?;
+
                 let s = (Tensor::ones((b, l), DType::I64, device)? * 20.)?;
                 let mut h_v_stack = vec![h_v.clone()];
 

--- a/ferritin-featurizers/src/models/ligandmpnn/model.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/model.rs
@@ -175,7 +175,6 @@ impl EncLayer {
             let scale = if self.scale == 0.0 { 1.0 } else { self.scale };
             (sum / scale)?
         };
-
         println!("metal 05");
         let h_v = {
             let dh_dropout = self
@@ -185,20 +184,24 @@ impl EncLayer {
             let h_v = h_v.to_dtype(DType::F32)?;
             self.norm1.forward(&(h_v + dh_dropout)?)?
         };
-
+        println!("metal 06");
         let dh = self.dense.forward(&h_v)?;
+        println!("metal 07");
         let h_v = {
             let dh_dropout = self
                 .dropout2
                 .forward(&dh, training.expect("Training Must be specified"))?;
             self.norm2.forward(&(&h_v + &dh_dropout)?)?
         };
+        println!("metal 08");
         let h_v = if let Some(mask) = mask_v {
             mask.unsqueeze(D::Minus1)?.broadcast_mul(&h_v)?
         } else {
             h_v
         };
+        println!("metal 09");
         let h_ev = cat_neighbors_nodes(&h_v, h_e, e_idx)?;
+        println!("metal 10");
         let h_v_expand = h_v.unsqueeze(D::Minus2)?;
 
         // Explicitly specify the expansion dimensions
@@ -208,9 +211,11 @@ impl EncLayer {
             h_ev.dims()[2],       // number of neighbors
             h_v_expand.dims()[3], // hidden dimension
         ];
+        println!("metal 11");
         let h_v_expand = h_v_expand.expand(&expand_shape)?;
         let h_v_expand = h_v_expand.to_dtype(h_ev.dtype())?;
-        let h_ev = Tensor::cat(&[&h_v_expand, &h_ev], D::Minus1)?;
+        let h_ev = Tensor::cat(&[&h_v_expand, &h_ev], D::Minus1)?.contiguous()?;
+        println!("metal 12");
         let h_message = self
             .w11
             .forward(&h_ev)?

--- a/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
@@ -74,8 +74,6 @@ impl ProteinFeaturesModel {
         // 5. Applies the RBF formula: exp(-(x-μ)²/σ²)
         const D_MIN: f64 = 2.0;
         const D_MAX: f64 = 22.0;
-
-        println!("d-Mu....");
         // Create centers (μ)
         let d_mu = linspace(D_MIN, D_MAX, self.num_rbf, &Device::Cpu)? // Use CPU device
             .to_dtype(DType::F32)? // Convert to F32 on CPU
@@ -252,12 +250,6 @@ impl ProteinFeaturesModel {
             .to_dtype(DType::U32)?;
 
         // E_chains = gather_edges(d_chains[:, :, :, None], E_idx)[:, :, :, 0]
-        println!(
-            "Dtypes for dechains and e_idx:  {:?}, {:?}",
-            d_chains.dtype(),
-            e_idx.dtype()
-        );
-
         let e_chains = gather_edges(&d_chains.unsqueeze(D::Minus1)?, &e_idx)?.squeeze(D::Minus1)?;
 
         println!("About to start the embeddings calculation...");
@@ -311,7 +303,6 @@ impl PositionalEncodings {
         println!("In positional Embedding: forward");
 
         let max_rel = self.max_relative_feature as f64;
-
         // First part: clip(offset + max_rel, 0, 2*max_rel)
         let d = (offset + max_rel)?;
         let d = d.clamp(0f64, 2.0 * max_rel)?;
@@ -323,10 +314,11 @@ impl PositionalEncodings {
         let d = (masked_d + extra_term?)?;
 
         // Convert to integers for one_hot
-        let d = d.to_dtype(DType::I64)?;
+        let d = d.to_dtype(DType::U32)?;
 
         // one_hot with correct depth using candle_nn::encoding::one_hot
         let depth = (2 * self.max_relative_feature + 2) as i64;
+        println!("Depth before one hot {}", depth);
         let d_onehot = one_hot(d, depth as usize, 1f32, 0f32)?;
         let d_onehot_float = d_onehot.to_dtype(DType::F32)?;
 

--- a/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
@@ -271,6 +271,7 @@ impl ProteinFeaturesModel {
         let e = Tensor::cat(&[e_positional, rbf_all], D::Minus1)?;
         let e = self.edge_embedding.forward(&e)?;
         println!("About to start the normalization...");
+
         let e = self.norm_edges.forward(&e)?;
         Ok((e, e_idx))
     }

--- a/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
@@ -203,9 +203,7 @@ impl ProteinFeaturesModel {
         let (d_neighbors, e_idx) = self._dist(&ca, &mask, self.augment_eps as f64)?;
 
         let mut rbf_all = Vec::new();
-        println!("RBF Device: {:?}", device);
         rbf_all.push(self._rbf(&d_neighbors, device)?);
-        println!("RBF Device _get_rbf");
         rbf_all.push(self._get_rbf(&n, &n, &e_idx, device)?);
         rbf_all.push(self._get_rbf(&c, &c, &e_idx, device)?);
         rbf_all.push(self._get_rbf(&o, &o, &e_idx, device)?);
@@ -232,10 +230,8 @@ impl ProteinFeaturesModel {
         rbf_all.push(self._get_rbf(&c, &o, &e_idx, device)?);
 
         let rbf_all = Tensor::cat(&rbf_all, D::Minus1)?;
-
         let dims = r_idx.dims();
         let target_shape = (dims[0], dims[1], dims[1]);
-        println!("I am in the RBF");
         let r_idx_expanded1 = r_idx
             .unsqueeze(2)?
             .broadcast_as(target_shape)?
@@ -248,7 +244,6 @@ impl ProteinFeaturesModel {
         let offset = (r_idx_expanded1 - r_idx_expanded2)?;
         let offset = gather_edges(&offset.unsqueeze(D::Minus1)?, &e_idx)?;
         let offset = offset.squeeze(D::Minus1)?;
-
         let dims = chain_labels.dims();
         let target_shape = (dims[0], dims[1], dims[1]);
         let d_chains = (&chain_labels.unsqueeze(2)?.broadcast_as(target_shape)?
@@ -257,6 +252,12 @@ impl ProteinFeaturesModel {
             .to_dtype(DType::I64)?;
 
         // E_chains = gather_edges(d_chains[:, :, :, None], E_idx)[:, :, :, 0]
+        println!(
+            "Dtypes for dechains and e_idx:  {:?}, {:?}",
+            d_chains.dtype(),
+            e_idx.dtype()
+        );
+
         let e_chains = gather_edges(&d_chains.unsqueeze(D::Minus1)?, &e_idx)?.squeeze(D::Minus1)?;
 
         println!("About to start the embeddings calculation...");

--- a/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
@@ -35,7 +35,6 @@ impl ProteinFeaturesModel {
             vb.device(),               // device this should be passed in as param,
             vb.pp("embeddings"),       // VarBuilder,
         )?;
-
         let edge_embedding =
             linear::linear_no_bias(edge_in, edge_features, vb.pp("edge_embedding"))?;
         let norm_edges = layer_norm(
@@ -88,7 +87,12 @@ impl ProteinFeaturesModel {
         let d_mu_broadcast = d_mu.broadcast_as((dims[0], dims[1], dims[2], self.num_rbf))?;
         let d_expanded_broadcast =
             d_expanded.broadcast_as((dims[0], dims[1], dims[2], self.num_rbf))?;
-
+        println!(
+            "Devices for d_expanded_broadcast,d_mu_broadcast, d_mu : {:?}, {:?}, {:?} ",
+            d_expanded_broadcast.device(),
+            d_mu_broadcast.device(),
+            d_mu.device()
+        );
         let diff = ((d_expanded_broadcast - d_mu_broadcast)? / d_sigma)?;
         let rbf = diff.powf(2.0)?.neg()?.exp()?;
 
@@ -201,6 +205,7 @@ impl ProteinFeaturesModel {
         let (d_neighbors, e_idx) = self._dist(&ca, &mask, self.augment_eps as f64)?;
 
         let mut rbf_all = Vec::new();
+        println!("RBF Device: {:?}", device);
         rbf_all.push(self._rbf(&d_neighbors, device)?);
         rbf_all.push(self._get_rbf(&n, &n, &e_idx, device)?);
         rbf_all.push(self._get_rbf(&c, &c, &e_idx, device)?);

--- a/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
@@ -249,7 +249,7 @@ impl ProteinFeaturesModel {
         let d_chains = (&chain_labels.unsqueeze(2)?.broadcast_as(target_shape)?
             - &chain_labels.unsqueeze(1)?.broadcast_as(target_shape)?)?
             .eq(0.0)?
-            .to_dtype(DType::I64)?;
+            .to_dtype(DType::U32)?;
 
         // E_chains = gather_edges(d_chains[:, :, :, None], E_idx)[:, :, :, 0]
         println!(
@@ -263,7 +263,7 @@ impl ProteinFeaturesModel {
         println!("About to start the embeddings calculation...");
         let e_positional = self
             .embeddings
-            .forward(&offset.to_dtype(DType::I64)?, &e_chains)?;
+            .forward(&offset.to_dtype(DType::U32)?, &e_chains)?;
 
         println!("About to cat the pos embeddings...");
 

--- a/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/proteinfeatures.rs
@@ -249,29 +249,15 @@ impl ProteinFeaturesModel {
             - &chain_labels.unsqueeze(1)?.broadcast_as(target_shape)?)?
             .eq(0.0)?
             .to_dtype(DType::U32)?;
-
         // E_chains = gather_edges(d_chains[:, :, :, None], E_idx)[:, :, :, 0]
         let e_chains = gather_edges(&d_chains.unsqueeze(D::Minus1)?, &e_idx)?.squeeze(D::Minus1)?;
-        println!("About to start the embeddings calculation...");
-        println!(
-            "Offset dims: {:?}, dtype: {:?}",
-            offset.dims(),
-            offset.dtype()
-        );
-        println!(
-            "e_chains dims: {:?}, dtype: {:?}",
-            e_chains.dims(),
-            e_chains.dtype()
-        );
         let e_positional = self
             .embeddings
             .forward(&offset.to_dtype(DType::U32)?, &e_chains)?;
-
         println!("About to cat the pos embeddings...");
         let e = Tensor::cat(&[e_positional, rbf_all], D::Minus1)?;
         let e = self.edge_embedding.forward(&e)?;
         println!("About to start the normalization...");
-
         let e = self.norm_edges.forward(&e)?;
         Ok((e, e_idx))
     }

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -784,7 +784,7 @@ mod tests {
         assert_eq!(indices.dims(), &[2, 3, 2]); // [batch, seq_len, k]
 
         // For first sequence, point [1,0,0] should have [0,0,0] and [2,0,0] as nearest neighbors
-        let point_neighbors: Vec<i64> = indices.i((0, 1, ..)).unwrap().to_vec1().unwrap();
+        let point_neighbors: Vec<u32> = indices.i((0, 1, ..)).unwrap().to_vec1().unwrap();
         assert_eq!(point_neighbors, vec![0, 2]);
 
         // Check distances are correct

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -57,6 +57,7 @@ pub fn compute_nearest_neighbors(
     k: usize,
     eps: f32,
 ) -> Result<(Tensor, Tensor)> {
+    // Todo: fix the F32/F64 issue
     let (_batch_size, seq_len, _) = coords.dims3()?;
 
     // broadcast_matmul handles broadcasting automatically
@@ -64,7 +65,7 @@ pub fn compute_nearest_neighbors(
     let mask_2d = mask
         .unsqueeze(2)?
         .broadcast_matmul(&mask.unsqueeze(1)?)?
-        .to_dtype(DType::F64)?; // Convert to f64 once, at the start
+        .to_dtype(DType::F32)?; // Convert to f64 once, at the start
 
     // Compute pairwise distances with broadcasting
     let distances = (coords
@@ -73,7 +74,8 @@ pub fn compute_nearest_neighbors(
         .powf(2.)?
         .sum(D::Minus1)?
         + eps as f64)?
-        .sqrt()?;
+        .sqrt()?
+        .to_dtype(DType::F32)?;
 
     // Apply mask
     // Get max values for adjustment

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -304,7 +304,8 @@ pub fn gather_nodes(nodes: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {
     let neighbors_flat = neighbors_flat
         .unsqueeze(2)? // Add feature dimension [B, N*K, 1]
         .expand((batch_size, n_nodes * k_neighbors, n_features))?; // Expand to [B, N*K, C]
-                                                                   // make contiguous for the gather.
+
+    // make contiguous for the gather.
     let neighbors_flat = neighbors_flat.contiguous()?;
     // Gather features
     let neighbor_features = nodes.gather(&neighbors_flat, 1)?;

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -91,13 +91,9 @@ pub fn compute_nearest_neighbors(
 
 // https://github.com/huggingface/candle/pull/2375/files#diff-e4d52a71060a80ac8c549f2daffcee77f9bf4de8252ad067c47b1c383c3ac828R957
 pub fn topk_last_dim(xs: &Tensor, topk: usize) -> Result<(Tensor, Tensor)> {
-    println!("topk_last_dim!");
     let sorted_indices = xs.arg_sort_last_dim(false)?.to_dtype(DType::U32)?;
-    println!("topk_last_dim!");
     let topk_indices = sorted_indices.narrow(D::Minus1, 0, topk)?.contiguous()?;
-    println!("topk_last_dim!");
     let gathered = xs.gather(&topk_indices, D::Minus1)?;
-    println!("gatheres!");
     Ok((gathered, topk_indices))
 }
 

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -283,14 +283,15 @@ pub fn cross_product(a: &Tensor, b: &Tensor) -> Result<Tensor> {
 /// Features [B,N,N,C] at Neighbor indices [B,N,K] => Neighbor features [B,N,K,C]
 pub fn gather_edges(edges: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {
     let (d1, d2, d3) = neighbor_idx.dims3()?;
+    println!("neighbor_idx dtype {:?}", neighbor_idx.dtype());
     let neighbors =
         neighbor_idx
             .unsqueeze(D::Minus1)?
             .expand((d1, d2, d3, edges.dim(D::Minus1)?))?;
 
-    // println!("Neighbors idx: {:?}", neighbors.dims());
+    println!("Neighbors idx: {:?}", neighbors.dims());
     let edge_gather = edges.gather(&neighbors, 2)?;
-    // println!("edge_gather idx: {:?}", edge_gather.dims());
+    println!("edge_gather idx: {:?}", edge_gather.dims());
     Ok(edge_gather)
 }
 

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -36,29 +36,16 @@ pub fn cat_neighbors_nodes(
     e_idx: &Tensor,
 ) -> Result<Tensor> {
     let h_nodes_gathered = gather_nodes(h_nodes, e_idx)?;
-    // println!("h_nodes_gathered dims: {:?}", h_nodes_gathered.dims());
-    // println!("h_neighbors dims: {:?}", h_neighbors.dims());
-    // todo: fix this hacky Dtype
-    //
     let h_neighbors = h_neighbors.expand((
         h_neighbors.dim(0)?, // 1
         h_nodes.dim(1)?,     // 93
         h_neighbors.dim(2)?, // 24
         h_neighbors.dim(3)?, // 128
     ))?;
-
-    // println!("h_neighbors dims 02: {:?}", h_neighbors.dims());
-
     let ten = Tensor::cat(
         &[h_neighbors, h_nodes_gathered.to_dtype(DType::F32)?],
         D::Minus1,
     );
-
-    // let dims = &ten.as_ref().unwrap().dims();
-
-    // println!("tensorcat: {:?}", dims);
-
-    // assert_eq!(true, false);
     ten
 }
 
@@ -309,32 +296,18 @@ pub fn gather_edges(edges: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {
 /// Features [B,N,C] at Neighbor indices [B,N,K] => [B,N,K,C]
 /// Flatten and expand indices per batch [B,N,K] => [B,NK] => [B,NK,C]
 pub fn gather_nodes(nodes: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {
-    // print!(
-    //     "IN GATHER NODES. Nodes, neighbor_idx: {:?}, {:?}",
-    //     nodes.dims(),
-    //     neighbor_idx.dims()
-    // );
     let (batch_size, n_nodes, n_features) = nodes.dims3()?;
     let (_, _, k_neighbors) = neighbor_idx.dims3()?;
-
     // Reshape neighbor_idx to [B, N*K]
     let neighbors_flat = neighbor_idx.reshape((batch_size, n_nodes * k_neighbors))?;
-
     // Add feature dimension and expand
     let neighbors_flat = neighbors_flat
         .unsqueeze(2)? // Add feature dimension [B, N*K, 1]
         .expand((batch_size, n_nodes * k_neighbors, n_features))?; // Expand to [B, N*K, C]
-
-    // make contiguous for the gather.
+                                                                   // make contiguous for the gather.
     let neighbors_flat = neighbors_flat.contiguous()?;
     // Gather features
     let neighbor_features = nodes.gather(&neighbors_flat, 1)?;
-
-    // println!(
-    //     "neighbor_features dims before final reshape: {:?}",
-    //     neighbor_features.dims()
-    // );
-
     // Reshape back to [B, N, K, C]
     neighbor_features.reshape((batch_size, n_nodes, k_neighbors, n_features))
 }
@@ -607,25 +580,29 @@ mod tests {
         // ATOM   4    O  O   . MET A 1 1   ? 26.748 9.469   -10.197 1.00 37.13  ? 0   MET A O   1
         let backbone_coords = [
             // Methionine - AA00
-            ("N", (0,0, 0, ..), vec![24.277, 8.374, -9.854]),
+            ("N", (0, 0, 0, ..), vec![24.277, 8.374, -9.854]),
             ("CA", (0, 0, 1, ..), vec![24.404, 9.859, -9.939]),
             ("C", (0, 0, 2, ..), vec![25.814, 10.249, -10.359]),
             ("O", (0, 0, 3, ..), vec![26.748, 9.469, -10.197]),
             // Valine - AA01
-            ("N", (0,1, 0, ..), vec![25.964, 11.453, -10.903]),
-            ("CA", (0,1, 1, ..), vec![27.263, 11.924, -11.359]),
-            ("C", (0,1, 2, ..), vec![27.392, 13.428, -11.115]),
-            ("O", (0,1, 3, ..), vec![26.443, 14.184, -11.327]),
+            ("N", (0, 1, 0, ..), vec![25.964, 11.453, -10.903]),
+            ("CA", (0, 1, 1, ..), vec![27.263, 11.924, -11.359]),
+            ("C", (0, 1, 2, ..), vec![27.392, 13.428, -11.115]),
+            ("O", (0, 1, 3, ..), vec![26.443, 14.184, -11.327]),
             // Glycing - AAlast
-            ("N", (0,153, 0, ..), vec![23.474, -3.227, 5.994]),
-            ("CA", (0,153, 1, ..), vec![22.818, -2.798, 7.211]),
-            ("C", (0,153, 2, ..), vec![22.695, -1.282, 7.219]),
-            ("O", (0,153, 3, ..), vec![21.870, -0.745, 7.992]),
+            ("N", (0, 153, 0, ..), vec![23.474, -3.227, 5.994]),
+            ("CA", (0, 153, 1, ..), vec![22.818, -2.798, 7.211]),
+            ("C", (0, 153, 2, ..), vec![22.695, -1.282, 7.219]),
+            ("O", (0, 153, 3, ..), vec![21.870, -0.745, 7.992]),
         ];
 
         for (atom_name, (b, i, j, k), expected) in backbone_coords {
             // assert_eq!(ac_backbone_tensor.dims(), &[1, 154, 4, 3])
-            let actual: Vec<f32> = ac_backbone_tensor.i((b, i, j, k)).unwrap().to_vec1().unwrap();
+            let actual: Vec<f32> = ac_backbone_tensor
+                .i((b, i, j, k))
+                .unwrap()
+                .to_vec1()
+                .unwrap();
             println!("ACTUAL: {:?}", actual);
             assert_eq!(actual, expected, "Mismatch for atom {}", atom_name);
         }
@@ -666,45 +643,49 @@ mod tests {
             // Methionine - AA00
             // We iterate through these positions. Not all AA's have each
             ("N", (0, 0, 0, ..), vec![24.277, 8.374, -9.854]),
-            ("CA", (0,0, 1, ..), vec![24.404, 9.859, -9.939]),
-            ("C", (0,0, 2, ..), vec![25.814, 10.249, -10.359]),
-            ("CB", (0,0, 3, ..), vec![24.070, 10.495, -8.596]),
-            ("O", (0,0, 4, ..), vec![26.748, 9.469, -10.197]),
-            ("CG", (0,0, 5, ..), vec![24.880, 9.939, -7.442]),
-            ("CG1", (0,0, 6, ..), vec![0.0, 0.0, 0.0]),
-            ("CG2", (0,0, 7, ..), vec![0.0, 0.0, 0.0]),
-            ("OG", (0,0, 8, ..), vec![0.0, 0.0, 0.0]),
-            ("OG1", (0,0, 9, ..), vec![0.0, 0.0, 0.0]),
-            ("SG", (0,0, 10, ..), vec![0.0, 0.0, 0.0]),
-            ("CD", (0,0, 11, ..), vec![0.0, 0.0, 0.0]),
-            ("CD1", (0,0, 12, ..), vec![0.0, 0.0, 0.0]),
-            ("CD2", (0,0, 13, ..), vec![0.0, 0.0, 0.0]),
-            ("ND1", (0,0, 14, ..), vec![0.0, 0.0, 0.0]),
-            ("ND2", (0,0, 15, ..), vec![0.0, 0.0, 0.0]),
-            ("OD1", (0,0, 16, ..), vec![0.0, 0.0, 0.0]),
-            ("OD2", (0,0, 17, ..), vec![0.0, 0.0, 0.0]),
-            ("SD", (0,0, 18, ..), vec![24.262, 10.555, -5.873]),
-            ("CE", (0,0, 19, ..), vec![24.822, 12.266, -5.967]),
-            ("CE1", (0,0, 20, ..), vec![0.0, 0.0, 0.0]),
-            ("CE2", (0,0, 21, ..), vec![0.0, 0.0, 0.0]),
-            ("CE3", (0,0, 22, ..), vec![0.0, 0.0, 0.0]),
-            ("NE", (0,0, 23, ..), vec![0.0, 0.0, 0.0]),
-            ("NE1", (0,0, 24, ..), vec![0.0, 0.0, 0.0]),
-            ("NE2", (0,0, 25, ..), vec![0.0, 0.0, 0.0]),
-            ("OE1", (0,0, 26, ..), vec![0.0, 0.0, 0.0]),
-            ("OE2", (0,0, 27, ..), vec![0.0, 0.0, 0.0]),
-            ("CH2", (0,0, 28, ..), vec![0.0, 0.0, 0.0]),
-            ("NH1", (0,0, 29, ..), vec![0.0, 0.0, 0.0]),
-            ("NH2", (0,0, 30, ..), vec![0.0, 0.0, 0.0]),
-            ("OH", (0,0, 31, ..), vec![0.0, 0.0, 0.0]),
-            ("CZ", (0,0, 32, ..), vec![0.0, 0.0, 0.0]),
-            ("CZ2", (0,0, 33, ..), vec![0.0, 0.0, 0.0]),
-            ("CZ3", (0, 0,34, ..), vec![0.0, 0.0, 0.0]),
-            ("NZ", (0, 0,35, ..), vec![0.0, 0.0, 0.0]),
-            ("OXT", (0, 0,36, ..), vec![0.0, 0.0, 0.0]),
+            ("CA", (0, 0, 1, ..), vec![24.404, 9.859, -9.939]),
+            ("C", (0, 0, 2, ..), vec![25.814, 10.249, -10.359]),
+            ("CB", (0, 0, 3, ..), vec![24.070, 10.495, -8.596]),
+            ("O", (0, 0, 4, ..), vec![26.748, 9.469, -10.197]),
+            ("CG", (0, 0, 5, ..), vec![24.880, 9.939, -7.442]),
+            ("CG1", (0, 0, 6, ..), vec![0.0, 0.0, 0.0]),
+            ("CG2", (0, 0, 7, ..), vec![0.0, 0.0, 0.0]),
+            ("OG", (0, 0, 8, ..), vec![0.0, 0.0, 0.0]),
+            ("OG1", (0, 0, 9, ..), vec![0.0, 0.0, 0.0]),
+            ("SG", (0, 0, 10, ..), vec![0.0, 0.0, 0.0]),
+            ("CD", (0, 0, 11, ..), vec![0.0, 0.0, 0.0]),
+            ("CD1", (0, 0, 12, ..), vec![0.0, 0.0, 0.0]),
+            ("CD2", (0, 0, 13, ..), vec![0.0, 0.0, 0.0]),
+            ("ND1", (0, 0, 14, ..), vec![0.0, 0.0, 0.0]),
+            ("ND2", (0, 0, 15, ..), vec![0.0, 0.0, 0.0]),
+            ("OD1", (0, 0, 16, ..), vec![0.0, 0.0, 0.0]),
+            ("OD2", (0, 0, 17, ..), vec![0.0, 0.0, 0.0]),
+            ("SD", (0, 0, 18, ..), vec![24.262, 10.555, -5.873]),
+            ("CE", (0, 0, 19, ..), vec![24.822, 12.266, -5.967]),
+            ("CE1", (0, 0, 20, ..), vec![0.0, 0.0, 0.0]),
+            ("CE2", (0, 0, 21, ..), vec![0.0, 0.0, 0.0]),
+            ("CE3", (0, 0, 22, ..), vec![0.0, 0.0, 0.0]),
+            ("NE", (0, 0, 23, ..), vec![0.0, 0.0, 0.0]),
+            ("NE1", (0, 0, 24, ..), vec![0.0, 0.0, 0.0]),
+            ("NE2", (0, 0, 25, ..), vec![0.0, 0.0, 0.0]),
+            ("OE1", (0, 0, 26, ..), vec![0.0, 0.0, 0.0]),
+            ("OE2", (0, 0, 27, ..), vec![0.0, 0.0, 0.0]),
+            ("CH2", (0, 0, 28, ..), vec![0.0, 0.0, 0.0]),
+            ("NH1", (0, 0, 29, ..), vec![0.0, 0.0, 0.0]),
+            ("NH2", (0, 0, 30, ..), vec![0.0, 0.0, 0.0]),
+            ("OH", (0, 0, 31, ..), vec![0.0, 0.0, 0.0]),
+            ("CZ", (0, 0, 32, ..), vec![0.0, 0.0, 0.0]),
+            ("CZ2", (0, 0, 33, ..), vec![0.0, 0.0, 0.0]),
+            ("CZ3", (0, 0, 34, ..), vec![0.0, 0.0, 0.0]),
+            ("NZ", (0, 0, 35, ..), vec![0.0, 0.0, 0.0]),
+            ("OXT", (0, 0, 36, ..), vec![0.0, 0.0, 0.0]),
         ];
-        for (atom_name, (b,i, j, k), expected) in allatom_coords {
-            let actual: Vec<f32> = ac_backbone_tensor.i((b, i, j, k)).unwrap().to_vec1().unwrap();
+        for (atom_name, (b, i, j, k), expected) in allatom_coords {
+            let actual: Vec<f32> = ac_backbone_tensor
+                .i((b, i, j, k))
+                .unwrap()
+                .to_vec1()
+                .unwrap();
             assert_eq!(actual, expected, "Mismatch for atom {}", atom_name);
         }
     }
@@ -783,7 +764,9 @@ mod tests {
             ],
             &device,
         )
-        .unwrap().to_dtype(test_dtype).unwrap();
+        .unwrap()
+        .to_dtype(test_dtype)
+        .unwrap();
 
         // Create mask indicating all points are valid
         let mask = Tensor::ones((2, 3), test_dtype, &device).unwrap();

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -91,9 +91,14 @@ pub fn compute_nearest_neighbors(
 
 // https://github.com/huggingface/candle/pull/2375/files#diff-e4d52a71060a80ac8c549f2daffcee77f9bf4de8252ad067c47b1c383c3ac828R957
 pub fn topk_last_dim(xs: &Tensor, topk: usize) -> Result<(Tensor, Tensor)> {
-    let sorted_indices = xs.arg_sort_last_dim(false)?.to_dtype(DType::I64)?;
+    println!("topk_last_dim!");
+    let sorted_indices = xs.arg_sort_last_dim(false)?.to_dtype(DType::U32)?;
+    println!("topk_last_dim!");
     let topk_indices = sorted_indices.narrow(D::Minus1, 0, topk)?.contiguous()?;
-    Ok((xs.gather(&topk_indices, D::Minus1)?, topk_indices))
+    println!("topk_last_dim!");
+    let gathered = xs.gather(&topk_indices, D::Minus1)?;
+    println!("gatheres!");
+    Ok((gathered, topk_indices))
 }
 
 /// Input coords. Output 1 <batch  x 1 > Tensor

--- a/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
+++ b/ferritin-featurizers/src/models/ligandmpnn/utilities.rs
@@ -283,15 +283,11 @@ pub fn cross_product(a: &Tensor, b: &Tensor) -> Result<Tensor> {
 /// Features [B,N,N,C] at Neighbor indices [B,N,K] => Neighbor features [B,N,K,C]
 pub fn gather_edges(edges: &Tensor, neighbor_idx: &Tensor) -> Result<Tensor> {
     let (d1, d2, d3) = neighbor_idx.dims3()?;
-    println!("neighbor_idx dtype {:?}", neighbor_idx.dtype());
     let neighbors =
         neighbor_idx
             .unsqueeze(D::Minus1)?
             .expand((d1, d2, d3, edges.dim(D::Minus1)?))?;
-
-    println!("Neighbors idx: {:?}", neighbors.dims());
     let edge_gather = edges.gather(&neighbors, 2)?;
-    println!("edge_gather idx: {:?}", edge_gather.dims());
     Ok(edge_gather)
 }
 

--- a/ferritin-featurizers/tests/test_cli.rs
+++ b/ferritin-featurizers/tests/test_cli.rs
@@ -1,3 +1,6 @@
+//
+// cargo flamegraph --bin ferritin-featurizers -- run --seed 111 --pdb-path ferritin-test-data/data/structures/1bc8.cif --model-type protein_mpnn --out-folder testout
+// cargo instruments -t time --bin ferritin-featurizers -- run --seed 111 --pdb-path ferritin-test-data/data/structures/1bc8.cif --model-type protein_mpnn --out-folder testout
 use assert_cmd::Command;
 use ferritin_test_data::TestFile;
 use std::path::Path;


### PR DESCRIPTION
- adding Metal Feature to attempt speedup
- resulted in fixes to building/loading the model weights
- hitting several metal /CPU difference.

Mac Air M1:
Beginning:  274 seconds 
Current: 9  seconds 

30x speedup by using the Metal Device instead of CPU device. 

```shell
# command
RUST_BACKTRACE=1  cargo instruments -t time \
  --bin ferritin-featurizers \
  -- run --seed 111 \
  --pdb-path ferritin-test-data/data/structures/1bc8.cif \
  --model-type protein_mpnn \
  --out-folder testout
```
![image](https://github.com/user-attachments/assets/c2855ae6-5cff-4baa-999d-aa8cb55393c0)

![image](https://github.com/user-attachments/assets/353261de-47ee-4b07-9142-3f2d9f2f8c36)


Requires: https://github.com/huggingface/candle/pull/2656 and https://github.com/huggingface/candle/pull/2653